### PR TITLE
Do not use Function.prototype.bind for browser compat

### DIFF
--- a/lib/sinon-chai.js
+++ b/lib/sinon-chai.js
@@ -24,7 +24,7 @@
 }(function sinonChai(chai) {
     "use strict";
 
-    var slice = Function.prototype.call.bind(Array.prototype.slice);
+    var slice = Array.prototype.slice;
 
     function flagger(word) {
         Object.defineProperty(chai.Assertion.prototype, word, {
@@ -77,7 +77,7 @@
             var shouldBeAlways = this._always && typeof this.obj[alwaysSinonMethod] === "function";
             var sinonMethod = shouldBeAlways ? alwaysSinonMethod : sinonName;
 
-            var messages = getMessages(this.obj, action, nonNegatedSuffix, shouldBeAlways, slice(arguments));
+            var messages = getMessages(this.obj, action, nonNegatedSuffix, shouldBeAlways, slice.call(arguments));
             this.assert(this.obj[sinonMethod].apply(this.obj, arguments), messages.affirmative, messages.negative);
         });
     }


### PR DESCRIPTION
Since you are only using slice once, this should not be a big deal. `bind` does not exist in a lot of headless webkit drivers, like phantomjs. This fixes #5 as well, I think.
