### PR TITLE
Added support for checking against spy-calls

### DIFF
--- a/lib/sinon-chai.js
+++ b/lib/sinon-chai.js
@@ -21,9 +21,12 @@
     var slice = Array.prototype.slice;
 
     function isSpy(putativeSpy) {
-        return typeof putativeSpy === "function" &&
+        return (typeof putativeSpy === "function" &&
                typeof putativeSpy.getCall === "function" &&
-               typeof putativeSpy.calledWithExactly === "function";
+               typeof putativeSpy.calledWithExactly === "function") ||
+               (typeof putativeSpy.proxy === "function" &&
+               typeof putativeSpy.proxy.getCall === "function" &&
+               typeof putativeSpy.proxy.calledWithExactly === "function");
     }
 
     function assertIsAboutSpy(assertion) {
@@ -33,6 +36,7 @@
     }
 
     function getMessages(spy, action, nonNegatedSuffix, always, args) {
+        spy = spy.proxy || spy
         var verbPhrase = always ? "always have " : "have ";
         nonNegatedSuffix = nonNegatedSuffix || "";
 

--- a/test/messages.coffee
+++ b/test/messages.coffee
@@ -204,6 +204,14 @@
             expect(-> throwingSpy.should.have.always.thrown({ message: "x" })).to
                 .throw("expected spy to always have thrown { message: 'x' }")
 
+    describe "when used on a spy-call", ->
+        it "should expect properly on the call", ->
+            spy = sinon.spy()
+            spy()
+            call = spy.getCall(0)
+            expect(-> call.should.have.been.calledWith())
+                .not.to.throw()
+
     describe "when used on a non-spy", ->
         notSpy = ->
 


### PR DESCRIPTION
In pure sinon, it is possible to assert against spy-calls:

```
var spy = sinon.spy()
spy('abc')
var call = spy.getCall(0)
assert(true === call.calledWith('abc'))
assert(false === call.calledWith('def'))
```

sinon-chai should support this scenario, but `expect(call).to.have.been.calledWith('abc')` was rejected due to calls not being spies.

I have extended the spy-assert to check for spy-calls as well.
