### PR TITLE
Added support for shouldWithMatch assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ equivalent is also available.
         <td>spy.should.always.have.been.calledWithExactly(...args)</td>
     </tr>
     <tr>
+        <td>calledWithMatch</td>
+        <td>spy.should.have.been.calledWithMatch(...args)</td>
+    </tr>
+    <tr>
+        <td>alwaysCalledWithMatch</td>
+        <td>spy.should.always.have.been.calledWithMatch(...args)</td>
+    </tr>
+    <tr>
         <td>returned</td>
         <td>spy.should.have.returned(returnVal)</td>
     </tr>

--- a/lib/sinon-chai.js
+++ b/lib/sinon-chai.js
@@ -101,6 +101,7 @@
     sinonMethod("calledOn", "been called with %1 as this", ", but it was called with %t instead");
     sinonMethod("calledWith", "been called with arguments %*", "%C");
     sinonMethod("calledWithExactly", "been called with exact arguments %*", "%C");
+    sinonMethod("calledWithMatch", "been called with matching arguments %*", "%C");
     sinonMethod("returned", "returned %1");
     exceptionalSinonMethod("thrown", "threw", "thrown %1");
 }));

--- a/test/callArguments.coffee
+++ b/test/callArguments.coffee
@@ -3,12 +3,14 @@ describe "Call arguments", ->
     arg1 = null
     arg2 = null
     notArg = null
+    any = null
 
     beforeEach ->
         spy = sinon.spy()
         arg1 = "A"
         arg2 = "B"
         notArg = "C"
+        any = sinon.match.any
 
     describe "calledWith", ->
         it "should throw an assertion error when the spy is not called", ->
@@ -139,3 +141,68 @@ describe "Call arguments", ->
             expect(-> spy.should.always.have.been.calledWithExactly(arg1, arg2)).to.throw(AssertionError)
             expect(-> spy.should.have.always.been.calledWithExactly(arg1, arg2)).to.throw(AssertionError)
             expect(-> spy.should.have.been.always.calledWithExactly(arg1, arg2)).to.throw(AssertionError)
+
+    describe "calledWithMatch", ->
+        it "should throw an assertion error when the spy is not called", ->
+            expect(-> spy.should.have.been.calledWithMatch(any, any)).to.throw(AssertionError)
+
+        it "should not throw when the spy is called with the correct arguments", ->
+            spy(arg1, arg2)
+
+            expect(-> spy.should.have.been.calledWithMatch(any, any)).to.not.throw()
+            expect(-> spy.getCall(0).should.have.been.calledWithMatch(any, any)).to.not.throw()
+
+        it "should not throw when the spy is called with the correct arguments and more", ->
+            spy(arg1, arg2, notArg)
+
+            expect(-> spy.should.have.been.calledWithMatch(any, any)).to.not.throw()
+            expect(-> spy.getCall(0).should.have.been.calledWithMatch(any, any)).to.not.throw()
+
+        it "should throw an assertion error when the spy is called with incorrect arguments", ->
+            spy(notArg, arg1)
+
+            expect(-> spy.should.have.been.calledWithMatch(any, arg2)).to.throw(AssertionError)
+            expect(-> spy.getCall(0).should.have.been.calledWithMatch(arg1, any)).to.throw(AssertionError)
+
+        it "should not throw when the spy is called with incorrect arguments but then correct ones", ->
+            spy(notArg, arg1)
+            spy(arg1, arg2)
+
+            expect(-> spy.should.have.been.calledWithMatch(arg1, arg2)).to.not.throw()
+            expect(-> spy.getCall(1).should.have.been.calledWithMatch(arg1, arg2)).to.not.throw()
+
+
+    describe "always calledWithMatch", ->
+        it "should throw an assertion error when the spy is not called", ->
+            expect(-> spy.should.always.have.been.calledWithMatch(any, any)).to.throw(AssertionError)
+            expect(-> spy.should.have.always.been.calledWithMatch(arg1, any)).to.throw(AssertionError)
+            expect(-> spy.should.have.been.always.calledWithMatch(any, arg2)).to.throw(AssertionError)
+
+        it "should not throw when the spy is called with the correct arguments", ->
+            spy(arg1, arg2)
+
+            expect(-> spy.should.always.have.been.calledWithMatch(any, any)).to.not.throw()
+            expect(-> spy.should.have.always.been.calledWithMatch(any, arg2)).to.not.throw()
+            expect(-> spy.should.have.been.always.calledWithMatch(arg1, any)).to.not.throw()
+
+        it "should not throw when the spy is called with the correct arguments and more", ->
+            spy(arg1, arg2, notArg)
+
+            expect(-> spy.should.always.have.been.calledWithMatch(any, any)).to.not.throw()
+            expect(-> spy.should.have.always.been.calledWithMatch(any, arg2)).to.not.throw()
+            expect(-> spy.should.have.been.always.calledWithMatch(arg1, any)).to.not.throw()
+
+        it "should throw an assertion error when the spy is called with incorrect arguments", ->
+            spy(notArg, arg1)
+
+            expect(-> spy.should.always.have.been.calledWithMatch(any, arg2)).to.throw(AssertionError)
+            expect(-> spy.should.have.always.been.calledWithMatch(arg1, any)).to.throw(AssertionError)
+            expect(-> spy.should.have.been.always.calledWithMatch(arg1, arg2)).to.throw(AssertionError)
+
+        it "should throw an assertion error when the spy is called with incorrect arguments but then correct ones", ->
+            spy(notArg, arg1)
+            spy(arg1, arg2)
+
+            expect(-> spy.should.always.have.been.calledWithMatch(arg1, arg2)).to.throw(AssertionError)
+            expect(-> spy.should.have.always.been.calledWithMatch(arg1, arg2)).to.throw(AssertionError)
+            expect(-> spy.should.have.been.always.calledWithMatch(arg1, arg2)).to.throw(AssertionError)


### PR DESCRIPTION
I needed to use the shouldWithMatch assertions earlier today, and noticed that there was no support for them.  This commit fixes that.
