### PR TITLE
Prevent exception when object spied upon has a #proxy property of its own

### DIFF
--- a/lib/sinon-chai.js
+++ b/lib/sinon-chai.js
@@ -39,7 +39,9 @@
     function getMessages(spy, action, nonNegatedSuffix, always, args) {
         var verbPhrase = always ? "always have " : "have ";
         nonNegatedSuffix = nonNegatedSuffix || "";
-        spy = spy.proxy || spy;
+        if (isSpy(spy.proxy)) {
+          spy = spy.proxy;
+        }
 
         function printfArray(array) {
             return spy.printf.apply(spy, array);


### PR DESCRIPTION
We noticed when running tests with `.calledWith` against spine.js controllers that we were getting exceptions in `printfArray`, due to not being able to call `apply` on undefined:

```
        function printfArray(array) {
            return spy.printf.apply(spy, array);
        }
```

`printf` doesn't exist in that line, due to this line:

```
          spy = spy.proxy || spy;
```

It's only a problem if the spied-upon object has a `proxy` property of its own.  I think we should test that the proxy is indeed a spy (using the sinon-chai `isSpy()` test) before reassignment -- and that's what this patch does.

Thanks for making sinon-chai!

Cheers,
- Mike
