### PR TITLE
Add lint friendly assertions

### DIFF
--- a/lib/sinon-chai.js
+++ b/lib/sinon-chai.js
@@ -65,8 +65,9 @@
         };
     }
 
+    var addProperty = utils.addChainableNoop || utils.addProperty;
     function sinonProperty(name, action, nonNegatedSuffix) {
-        utils.addProperty(chai.Assertion.prototype, name, function () {
+        addProperty(chai.Assertion.prototype, name, function () {
             assertCanWorkWith(this);
 
             var messages = getMessages(this._obj, action, nonNegatedSuffix, false);


### PR DESCRIPTION
Starting in chai 1.10.0 there are callable assertion terminators available; see chaijs/chai#297. This change checks for this functionality and uses it if available.

These both will now be valid ways to assert for `called`, `calledOnce`, `calledTwice`, and `calledThrice`.

```
spy.should.have.been.calledOnce;
spy.should.have.been.calledOnce();
```
