### PR TITLE
Fixed anonymous define() error thrown by requirejs

### DIFF
--- a/lib/sinon-chai.js
+++ b/lib/sinon-chai.js
@@ -9,7 +9,7 @@
         module.exports = sinonChai;
     } else if (typeof define === "function" && define.amd) {
         // AMD
-        define(function () {
+        define("sinon-chai", function () {
             return sinonChai;
         });
     } else {


### PR DESCRIPTION
I had trouble using sinon-chai in a setup with [karma-sinon-chai](https://www.npmjs.com/package/karma-sinon-chai) because of the anonymous define() call. Giving an id fixes the problem and should not introduce any side effects because the [AMD Api](https://github.com/amdjs/amdjs-api/wiki/AMD) clearly specifies that id can optionally be assigned.
