### PR TITLE
Support chai 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha && opener ./coverage/lcov-report/lib/sinon-chai.js.html"
   },
   "peerDependencies": {
-    "chai": ">=1.9.2 <2",
+    "chai": ">=1.9.2 <3",
     "sinon": ">=1.4.0 <2"
   },
   "devDependencies": {


### PR DESCRIPTION
chai 2.0.0 was just released and it includes some great improvements as well as fixes.
https://github.com/chaijs/chai/blob/master/ReleaseNotes.md

All test cases for simon-chai passed for me (chai 2.0.0 was manually installed by `npm install chai@2`).