### PR TITLE
updated to use Chai 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "stubs",
     "mocks"
   ],
-  "version": "2.10.0",
+  "version": "2.10.1",
   "author": "Domenic Denicola <d@domenic.me> (https://domenic.me/)",
   "license": "(BSD-2-Clause OR WTFPL)",
   "repository": "domenic/sinon-chai",
@@ -28,11 +28,11 @@
     "cover": "istanbul cover node_modules/mocha/bin/_mocha && opener ./coverage/lcov-report/lib/sinon-chai.js.html"
   },
   "peerDependencies": {
-    "chai": ">=1.9.2 <4",
+    "chai": ">=1.9.2",
     "sinon": "^1.4.0 || ^2.1.0"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
+    "chai": "^4.0.0",
     "coffee-script": "~1.8.0",
     "istanbul": "~0.3.2",
     "jshint": "^2.5.6",


### PR DESCRIPTION
per #97 after running tests incremented version number and changed dependencies