### PR TITLE
Fix failing build

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coffee-script": "~1.8.0",
     "istanbul": "~0.3.2",
     "jshint": "^2.5.6",
-    "mocha": "^1.21.4",
+    "mocha": "^3.4.2",
     "opener": "^1.4.0",
     "sinon": "^2.1.0"
   }

--- a/test/callOrder.coffee
+++ b/test/callOrder.coffee
@@ -1,6 +1,7 @@
 "use strict"
 
 sinon = require("sinon")
+sinonIsVersion1 = require("sinon/package.json").version.charAt(0) == '1'
 
 describe "Call order", ->
     spy1 = null
@@ -39,6 +40,9 @@ describe "Call order", ->
             expect(-> spy1.should.have.been.calledBefore(spy2)).to.throw(AssertionError)
 
     describe "spy1 calledImmediatelyBefore spy2", ->
+        beforeEach ->
+          this.skip() if sinonIsVersion1
+
         it "should throw an assertion error when neither spy is called", ->
             expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
 
@@ -98,6 +102,9 @@ describe "Call order", ->
             expect(-> spy1.should.have.been.calledAfter(spy2)).to.not.throw()
 
     describe "spy1 calledImmediatelyAfter spy2", ->
+        beforeEach ->
+          this.skip() if sinonIsVersion1
+
         it "should throw an assertion error when neither spy is called", ->
             expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
 

--- a/test/callOrder.coffee
+++ b/test/callOrder.coffee
@@ -1,7 +1,6 @@
 "use strict"
 
 sinon = require("sinon")
-sinonIsVersion1 = require("sinon/package.json").version.charAt(0) == '1'
 
 describe "Call order", ->
     spy1 = null

--- a/test/common.js
+++ b/test/common.js
@@ -5,6 +5,8 @@ global.should = require("chai").should();
 global.expect = require("chai").expect;
 global.AssertionError = require("chai").AssertionError;
 
+global.sinonIsVersion1 = require("sinon/package.json").version.split('.')[0] == '1'
+
 global.swallow = function (thrower) {
     try {
         thrower();

--- a/test/messages.coffee
+++ b/test/messages.coffee
@@ -1,7 +1,6 @@
 ﻿"use strict"
 
 sinon = require("sinon")
-sinonIsVersion1 = require("sinon/package.json").version.charAt(0) == '1'
 
 describe "Messages", ->
     describe "about call count", ->

--- a/test/messages.coffee
+++ b/test/messages.coffee
@@ -1,6 +1,7 @@
 ﻿"use strict"
 
 sinon = require("sinon")
+sinonIsVersion1 = require("sinon/package.json").version.charAt(0) == '1'
 
 describe "Messages", ->
     describe "about call count", ->
@@ -53,6 +54,9 @@ describe "Messages", ->
                 .throw("expected spy to not have been called exactly 4 times")
 
     describe "about call order", ->
+        beforeEach ->
+          this.skip() if sinonIsVersion1
+
         it "should be correct for the base cases", ->
             spyA = sinon.spy()
             spyB = sinon.spy()


### PR DESCRIPTION
Sinon never implemented `calledImmediatelyBefore` and `calledImmediatelyAfter` in sinon v1, which is why the tests were failing.

This PR updates mocha so that we have access to the `skip` method and checks the sinon version before running tests that only pertain to sinon v2.