### PR TITLE
Only test "immediately" call order variants when they exist

### DIFF
--- a/test/callOrder.coffee
+++ b/test/callOrder.coffee
@@ -3,7 +3,7 @@
 sinon = require("sinon")
 
 describe "Call order", ->
-    spy1 = null
+    spy1 = sinon.spy() # used for testing when setting up tests
     spy2 = null
     spy3 = null
 
@@ -39,37 +39,38 @@ describe "Call order", ->
             expect(-> spy1.should.have.been.calledBefore(spy2)).to.throw(AssertionError)
 
     describe "spy1 calledImmediatelyBefore spy2", ->
-        it "should throw an assertion error when neither spy is called", ->
-            expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
+        if spy1.calledImmediatelyBefore
+            it "should throw an assertion error when neither spy is called", ->
+                expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
 
-        it "should throw an assertion error when only spy 1 is called", ->
-            spy1()
+            it "should throw an assertion error when only spy 1 is called", ->
+                spy1()
 
-            expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
+                expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
 
-        it "should throw an assertion error when only spy 2 is called", ->
-            spy2()
+            it "should throw an assertion error when only spy 2 is called", ->
+                spy2()
 
-            expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
+                expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
 
-        it "should not throw when spy 1 is called immediately before spy 2", ->
-            spy1()
-            spy2()
+            it "should not throw when spy 1 is called immediately before spy 2", ->
+                spy1()
+                spy2()
 
-            expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.not.throw()
+                expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.not.throw()
 
-        it "should throw an assertion error when spy 1 is called before spy 2, but not immediately", ->
-            spy2()
-            spy3()
-            spy1()
+            it "should throw an assertion error when spy 1 is called before spy 2, but not immediately", ->
+                spy2()
+                spy3()
+                spy1()
 
-            expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
+                expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
 
-        it "should throw an assertion error when spy 1 is called after spy 2", ->
-            spy2()
-            spy1()
+            it "should throw an assertion error when spy 1 is called after spy 2", ->
+                spy2()
+                spy1()
 
-            expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
+                expect(-> spy1.should.have.been.calledImmediatelyBefore(spy2)).to.throw(AssertionError)
 
     describe "spy1 calledAfter spy2", ->
         it "should throw an assertion error when neither spy is called", ->
@@ -98,35 +99,35 @@ describe "Call order", ->
             expect(-> spy1.should.have.been.calledAfter(spy2)).to.not.throw()
 
     describe "spy1 calledImmediatelyAfter spy2", ->
-        it "should throw an assertion error when neither spy is called", ->
-            expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
+        if spy1.calledImmediatelyAfter
+            it "should throw an assertion error when neither spy is called", ->
+                expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
 
-        it "should throw an assertion error when only spy 1 is called", ->
-            spy1()
+            it "should throw an assertion error when only spy 1 is called", ->
+                spy1()
 
-            expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
+                expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
 
-        it "should throw an assertion error when only spy 2 is called", ->
-            spy2()
+            it "should throw an assertion error when only spy 2 is called", ->
+                spy2()
 
-            expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
+                expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
 
-        it "should throw an assertion error when spy 1 is called before spy 2", ->
-            spy1()
-            spy2()
+            it "should throw an assertion error when spy 1 is called before spy 2", ->
+                spy1()
+                spy2()
 
-            expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
+                expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
 
-        it "should not throw when spy 1 is called immediately after spy 2", ->
-            spy2()
-            spy1()
+            it "should not throw when spy 1 is called immediately after spy 2", ->
+                spy2()
+                spy1()
 
-            expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.not.throw()
+                expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.not.throw()
 
-        it "should throw an assertion error when spy 1 is called after spy 2, but not immediately", ->
-            spy1()
-            spy3()
-            spy2()
+            it "should throw an assertion error when spy 1 is called after spy 2, but not immediately", ->
+                spy1()
+                spy3()
+                spy2()
 
-            expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)
-
+                expect(-> spy1.should.have.been.calledImmediatelyAfter(spy2)).to.throw(AssertionError)

--- a/test/messages.coffee
+++ b/test/messages.coffee
@@ -62,13 +62,17 @@ describe "Messages", ->
 
             expect(-> spyA.should.have.been.calledBefore(spyB)).to
                 .throw("expected spyA to have been called before function spyB() {}")
-            expect(-> spyA.should.have.been.calledImmediatelyBefore(spyB)).to
-                .throw("expected spyA to have been called immediately before function spyB() {}")
+
+            if spyA.calledImmediatelyBefore
+                expect(-> spyA.should.have.been.calledImmediatelyBefore(spyB)).to
+                    .throw("expected spyA to have been called immediately before function spyB() {}")
 
             expect(-> spyB.should.have.been.calledAfter(spyA)).to
                 .throw("expected spyB to have been called after function spyA() {}")
-            expect(-> spyB.should.have.been.calledImmediatelyAfter(spyA)).to
-                .throw("expected spyB to have been called immediately after function spyA() {}")
+
+            if spyB.calledImmediatelyAfter
+                expect(-> spyB.should.have.been.calledImmediatelyAfter(spyA)).to
+                    .throw("expected spyB to have been called immediately after function spyA() {}")
 
         it "should be correct for the negated cases", ->
             spyA = sinon.spy()
@@ -82,13 +86,17 @@ describe "Messages", ->
 
             expect(-> spyA.should.not.have.been.calledBefore(spyB)).to
                 .throw("expected spyA to not have been called before function spyB() {}")
-            expect(-> spyA.should.not.have.been.calledImmediatelyBefore(spyB)).to
-                .throw("expected spyA to not have been called immediately before function spyB() {}")
+
+            if spyA.calledImmediatelyBefore
+                expect(-> spyA.should.not.have.been.calledImmediatelyBefore(spyB)).to
+                    .throw("expected spyA to not have been called immediately before function spyB() {}")
 
             expect(-> spyB.should.not.have.been.calledAfter(spyA)).to
                 .throw("expected spyB to not have been called after function spyA() {}")
-            expect(-> spyB.should.not.have.been.calledImmediatelyAfter(spyA)).to
-                .throw("expected spyB to not have been called immediately after function spyA() {}")
+
+            if spyB.calledImmediatelyAfter
+                expect(-> spyB.should.not.have.been.calledImmediatelyAfter(spyA)).to
+                    .throw("expected spyB to not have been called immediately after function spyA() {}")
 
     describe "about call context", ->
         it "should be correct for the basic case", ->


### PR DESCRIPTION
This allows CI to pass even on older Sinon versions. Closes #100.