### PR TITLE
Fix incorrect example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Instead of using Sinon.JS's assertions:
 
 ```javascript
-sinon.assertCalledWith(mySpy, "foo");
+sinon.assert.calledWith(mySpy, "foo");
 ```
 
 or awkwardly trying to use Chai's `should` or `expect` interfaces on spy properties:


### PR DESCRIPTION
`sinon.assertCalledWith` should be [`sinon.assert.calledWith`](http://sinonjs.org/releases/v4.4.2/assertions/#sinonassertcalledwithspyorspycall-arg1-arg2-)