### PR TITLE
Add support for Sinon version 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 4
   - stable
 env:
+  - CHAI_VERSION=^4.0.0 SINON_VERSION=^6.0.0
   - CHAI_VERSION=^4.0.0 SINON_VERSION=^5.0.0
   - CHAI_VERSION=^4.0.0 SINON_VERSION=^4.0.0
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/@sinonjs/formatio/-/formatio-2.0.0.tgz?dl=https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
       "dev": true,
       "requires": {
         "samsam": "1.3.0"
@@ -124,9 +124,9 @@
       "dev": true
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/assertion-error/-/assertion-error-1.1.0.tgz?dl=https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "async": {
@@ -164,7 +164,7 @@
     },
     "browser-stdout": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/browser-stdout/-/browser-stdout-1.3.0.tgz?dl=https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
@@ -202,17 +202,17 @@
       }
     },
     "chai": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
-      "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
+      "version": "4.1.2",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/chai/-/chai-4.1.2.tgz?dl=https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "check-error": "1.0.2",
-        "deep-eql": "2.0.2",
+        "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.8"
       }
     },
     "chalk": {
@@ -230,7 +230,7 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/check-error/-/check-error-1.0.2.tgz?dl=https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
@@ -290,7 +290,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/commander/-/commander-2.9.0.tgz?dl=https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
@@ -346,20 +346,12 @@
       "optional": true
     },
     "deep-eql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
-      "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+      "version": "3.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/deep-eql/-/deep-eql-3.0.1.tgz?dl=https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
-        "type-detect": "3.0.0"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
-          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
-          "dev": true
-        }
+        "type-detect": "4.0.8"
       }
     },
     "deep-is": {
@@ -385,7 +377,7 @@
     },
     "diff": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/diff/-/diff-3.2.0.tgz?dl=https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
@@ -697,7 +689,7 @@
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/get-func-name/-/get-func-name-2.0.0.tgz?dl=https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
@@ -743,13 +735,13 @@
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz?dl=https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
       "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/growl/-/growl-1.9.2.tgz?dl=https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
@@ -789,6 +781,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/he/-/he-1.1.1.tgz?dl=https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
     "ignore": {
@@ -914,7 +912,7 @@
     },
     "isarray": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/isarray/-/isarray-0.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
@@ -1009,7 +1007,7 @@
     },
     "json3": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/json3/-/json3-3.3.2.tgz?dl=https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
@@ -1027,8 +1025,8 @@
     },
     "just-extend": {
       "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/just-extend/-/just-extend-1.1.27.tgz?dl=https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
       "dev": true
     },
     "kind-of": {
@@ -1065,7 +1063,7 @@
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz?dl=https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
@@ -1075,31 +1073,31 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz?dl=https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz?dl=https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz?dl=https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz?dl=https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.create/-/lodash.create-3.1.1.tgz?dl=https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
@@ -1110,25 +1108,25 @@
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.get/-/lodash.get-4.4.2.tgz?dl=https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz?dl=https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz?dl=https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.keys/-/lodash.keys-3.1.2.tgz?dl=https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -1138,9 +1136,9 @@
       }
     },
     "lolex": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.4.1.tgz",
-      "integrity": "sha512-8QdNQMqlAE2kkc2YWR3Ld0evgE452mmyYZR4HTh54PeH8UAjDipHYh/FHq6y9cAvM68nxGxj5jAz97+WQ2AQEQ==",
+      "version": "2.7.0",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lolex/-/lolex-2.7.0.tgz?dl=https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha1-nAh6aexEDjnT95Z2fPGyzcQ9XqU=",
       "dev": true
     },
     "longest": {
@@ -1174,9 +1172,9 @@
       }
     },
     "mocha": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
-      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "version": "3.5.3",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/mocha/-/mocha-3.5.3.tgz?dl=https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1186,6 +1184,7 @@
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
         "growl": "1.9.2",
+        "he": "1.1.1",
         "json3": "3.3.2",
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
@@ -1194,7 +1193,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/glob/-/glob-7.1.1.tgz?dl=https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
@@ -1208,7 +1207,7 @@
         },
         "supports-color": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/supports-color/-/supports-color-3.1.2.tgz?dl=https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
@@ -1236,14 +1235,14 @@
       "dev": true
     },
     "nise": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
-      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+      "version": "1.4.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/nise/-/nise-1.4.1.tgz?dl=https://registry.npmjs.org/nise/-/nise-1.4.1.tgz",
+      "integrity": "sha1-eLwrND1f8QMeqdG7LIepTCbbclA=",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "2.4.1",
+        "lolex": "2.7.0",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
       }
@@ -1348,7 +1347,7 @@
     },
     "path-to-regexp": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/path-to-regexp/-/path-to-regexp-1.7.0.tgz?dl=https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "dev": true,
       "requires": {
@@ -1357,7 +1356,7 @@
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/pathval/-/pathval-1.1.0.tgz?dl=https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
@@ -1532,8 +1531,8 @@
     },
     "samsam": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/samsam/-/samsam-1.3.0.tgz?dl=https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "shelljs": {
@@ -1548,40 +1547,40 @@
       }
     },
     "sinon": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.7.tgz",
-      "integrity": "sha512-GvNLrwpvLZ8jIMZBUhHGUZDq5wlUdceJWyHvZDmqBxnjazpxY1L0FNbGBX6VpcOEoQ8Q4XMWFzm2myJMvx+VjA==",
+      "version": "5.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/sinon/-/sinon-5.1.1.tgz?dl=https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
+      "integrity": "sha1-GcWYEP+3M+pudqKLlKcfxML1I7g=",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
-        "diff": "3.2.0",
+        "diff": "3.5.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.4.1",
-        "nise": "1.3.3",
+        "lolex": "2.7.0",
+        "nise": "1.4.1",
         "supports-color": "5.4.0",
         "type-detect": "4.0.8"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/diff/-/diff-3.5.0.tgz?dl=https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+          "dev": true
+        },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/has-flag/-/has-flag-3.0.0.tgz?dl=https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/supports-color/-/supports-color-5.4.0.tgz?dl=https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
-        },
-        "type-detect": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-          "dev": true
         }
       }
     },
@@ -1688,7 +1687,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/text-encoding/-/text-encoding-0.6.4.tgz?dl=https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -1720,9 +1719,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "version": "4.0.8",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/type-detect/-/type-detect-4.0.8.tgz?dl=https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "typedarray": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,7 +164,7 @@
     },
     "browser-stdout": {
       "version": "1.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/browser-stdout/-/browser-stdout-1.3.0.tgz?dl=https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
@@ -230,7 +230,7 @@
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/check-error/-/check-error-1.0.2.tgz?dl=https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
@@ -290,7 +290,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/commander/-/commander-2.9.0.tgz?dl=https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
@@ -377,7 +377,7 @@
     },
     "diff": {
       "version": "3.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/diff/-/diff-3.2.0.tgz?dl=https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
@@ -689,7 +689,7 @@
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/get-func-name/-/get-func-name-2.0.0.tgz?dl=https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
@@ -735,13 +735,13 @@
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz?dl=https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
       "version": "1.9.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/growl/-/growl-1.9.2.tgz?dl=https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
@@ -1007,7 +1007,7 @@
     },
     "json3": {
       "version": "3.3.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/json3/-/json3-3.3.2.tgz?dl=https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
@@ -1063,7 +1063,7 @@
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz?dl=https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
@@ -1073,31 +1073,31 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz?dl=https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz?dl=https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz?dl=https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz?dl=https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.create/-/lodash.create-3.1.1.tgz?dl=https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
@@ -1114,19 +1114,19 @@
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz?dl=https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz?dl=https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/lodash.keys/-/lodash.keys-3.1.2.tgz?dl=https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -1193,7 +1193,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.1",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/glob/-/glob-7.1.1.tgz?dl=https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
@@ -1207,7 +1207,7 @@
         },
         "supports-color": {
           "version": "3.1.2",
-          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/supports-color/-/supports-color-3.1.2.tgz?dl=https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
@@ -1356,7 +1356,7 @@
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/pathval/-/pathval-1.1.0.tgz?dl=https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
@@ -1547,9 +1547,9 @@
       }
     },
     "sinon": {
-      "version": "5.1.1",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/sinon/-/sinon-5.1.1.tgz?dl=https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
-      "integrity": "sha1-GcWYEP+3M+pudqKLlKcfxML1I7g=",
+      "version": "6.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/appconnect-npm/sinon/-/sinon-6.0.0.tgz?dl=https://registry.npmjs.org/sinon/-/sinon-6.0.0.tgz",
+      "integrity": "sha1-8mYn5IMNw0J5ZhR02iyeeE8WYhU=",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "peerDependencies": {
     "chai": "^4.0.0",
-    "sinon": ">=4.0.0 <6.0.0"
+    "sinon": ">=4.0.0 <7.0.0"
   },
   "devDependencies": {
-    "chai": "^4.1.0",
+    "chai": "^4.1.2",
     "eslint": "^3.19.0",
     "istanbul": "~0.4.5",
-    "mocha": "^3.4.2",
+    "mocha": "^3.5.3",
     "opener": "^1.4.3",
-    "sinon": "^5.0.0"
+    "sinon": "^6.0.0"
   }
 }


### PR DESCRIPTION
Support `sinon` version 6. Fixes #126.

This should be an easy change to adopt because there are ["no known breaking changes"](http://sinonjs.org/guides/migrating-to-6.0) in the new `sinon`.