### PR TITLE
Remove peer dependency upper restriction for sinon

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "chai": "^4.0.0",
-    "sinon": ">=4.0.0 <7.0.0"
+    "sinon": ">=4.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Currently the peer dependency for `sinon` is set to `>=4.0.0 <7.0.0`. The latest `sinon` version is `7.1.1`. This triggers a warning in npm every single time:
```
WARN sinon-chai@3.2.0 requires a peer of sinon@>=4.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
```

This change gets rid of the upper limit.